### PR TITLE
Update Account Checker to account for zero related accounts

### DIFF
--- a/modules/account.py
+++ b/modules/account.py
@@ -65,10 +65,14 @@ async def check_email(email: str):
 
         await asyncio.gather(*tasks)
 
+    resultCount = 0
     if exist:
         for result in exist:
             try:
                 if result[0]['exists']:
                     print(f"[{GREEN}{date}{WHITE}] {GREEN}{result[0]['name'].upper()}{WHITE}")
+                    resultCount += 1
             except:
                 pass
+    if resultCount == 0:
+        print(f"{RED}[-]{WHITE} {RED}No related accounts were found!{WHITE}\n")


### PR DESCRIPTION
Update Account Checker feature: Add a message when there are no/zero related accounts for a given email.

```
    resultCount = 0
    if exist:
        for result in exist:
            try:
                if result[0]['exists']:
                    print(f"[{GREEN}{date}{WHITE}] {GREEN}{result[0]['name'].upper()}{WHITE}")
                    resultCount += 1
            except:
                pass
    if resultCount == 0:
        print(f"{RED}[-]{WHITE} {RED}No related accounts were found!{WHITE}\n")
```