### PR TITLE
Fix ssl.SSLError

### DIFF
--- a/modules/account.py
+++ b/modules/account.py
@@ -63,7 +63,7 @@ async def check_email(email: str):
         out = []
         try:
             await module(email, client, out)
-        except httpx.ConnectError:
+        except (httpx.ConnectError, ssl.SSLError) as e:
             pass
         exist.append(out)
 


### PR DESCRIPTION
Fixed #2.
This problem, as I understand, depends on the holehe module (and that's why we can't just set a verify=False in the code) and depends on the website (bodybuilding.com), and so that's why we can just ignore checking this website (and other websites, that get the same problem) and continue checking other websites.

So, on my machine (MacOS), that didn't get sslerror, and on a docker image, that got it, I have the same output -> this fix generally doesn't affect on results.
